### PR TITLE
Ensure task worker marks queue items done

### DIFF
--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -5,14 +5,18 @@ _q = asyncio.Queue()
 async def worker():
     while True:
         tid = await _q.get()
-        task = _tasks.get(tid); 
-        if not task: continue
+        task = _tasks.get(tid)
+        if not task:
+            _q.task_done()
+            continue
         fn, payload = task["fn"], task["payload"]
         try:
             res = await fn(payload)
             task.update(status="done", result=res)
         except Exception as e:
             task.update(status="error", error=str(e))
+        finally:
+            _q.task_done()
 
 async def start_workers(n=1):
     for _ in range(n): asyncio.create_task(worker())

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,16 @@
+import asyncio
+import pytest
+from backend.api import tasks
+
+
+@pytest.mark.asyncio
+async def test_task_processing_marks_done_and_clears_queue():
+    async def dummy(payload):
+        await asyncio.sleep(0)
+        return payload.get("value", 1)
+
+    await tasks.start_workers(1)
+    tid = tasks.submit(dummy, {"value": 42})
+    await asyncio.wait_for(tasks._q.join(), timeout=1)
+
+    assert tasks.status(tid)["status"] == "done"


### PR DESCRIPTION
## Summary
- properly call `task_done()` for each task in the queue
- add regression test covering task processing

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897cbf087888326add6158693935673